### PR TITLE
Add LineWebhook install.kt example with channelSecret config

### DIFF
--- a/plugins/server/io.github.cotrin8672/line-webhook/2.0/install.kt
+++ b/plugins/server/io.github.cotrin8672/line-webhook/2.0/install.kt
@@ -1,0 +1,10 @@
+import io.ktor.server.application.*
+import io.ktor.server.plugins.*
+import io.github.cotrin8672.linewebhook.*
+
+fun Application.module() {
+    install(LineWebhook) {
+        channelSecret = System.getenv("LINE_CHANNEL_SECRET") 
+            ?: error("LINE_CHANNEL_SECRET not set")
+    }
+}


### PR DESCRIPTION
Fixes #131

This PR adds a missing `install.kt` usage example for the LineWebhook plugin.  
It shows how to configure `channelSecret` safely using environment variables:

```kotlin
install(LineWebhook) {
    channelSecret = System.getenv("LINE_CHANNEL_SECRET")
        ?: error("LINE_CHANNEL_SECRET not set")
}
